### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,6 +100,7 @@ jobs:
     needs: build_release
     runs-on: ubuntu-latest
     if: ${{ needs.build_release.outputs.RELEASE_TYPE == 'release' }}
+    permissions: {}
     env:
       VERSION: ${{ needs.build_release.outputs.VERSION }}
     steps:
@@ -145,6 +146,7 @@ jobs:
     needs: build_release
     runs-on: ubuntu-latest
     if: ${{ needs.build_release.outputs.RELEASE_TYPE == 'release' }}
+    permissions: {}
     env:
       VERSION: ${{ needs.build_release.outputs.VERSION }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/pol-rivero/doot/security/code-scanning/8](https://github.com/pol-rivero/doot/security/code-scanning/8)

In general, the fix is to add explicit `permissions` blocks to jobs that currently rely on the repository/org default `GITHUB_TOKEN` permissions, granting only the minimal scopes required. For jobs that do not use `GITHUB_TOKEN` at all, you can set `permissions: {}` or only allow `contents: read` if log/metadata access is needed.

For this workflow:

- `build_release` already sets `permissions: contents: write`, which is appropriate for creating releases.
- `publish_aur` only downloads artifacts and uses an external SSH key for AUR; it doesn’t need `GITHUB_TOKEN`, so we can disable it with `permissions: {}`.
- `publish_homebrew` checks out another repository using a PAT secret and pushes via that PAT; `GITHUB_TOKEN` is not required, so we can also disable it with `permissions: {}`.

Concretely:

- In `.github/workflows/release.yaml`, under job `publish_aur` (around line 99), insert a `permissions: {}` line, aligned with `needs:` and `runs-on:`.
- In the same file, under job `publish_homebrew` (around line 144), insert `permissions: {}` at the same indentation level as `needs:` and `runs-on:`.

No additional imports or methods are needed; this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
